### PR TITLE
Set `cad_component`'s `y` coordinate to `180` when it's on the bottom layer 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tscircuit/builder",
-  "version": "1.5.146",
+  "version": "1.5.149",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tscircuit/builder",
-      "version": "1.5.146",
+      "version": "1.5.149",
       "license": "MIT",
       "dependencies": {
         "@lume/kiwi": "^0.1.0",

--- a/src/lib/builder/component-builder/ComponentBuilder.ts
+++ b/src/lib/builder/component-builder/ComponentBuilder.ts
@@ -447,6 +447,11 @@ export class ComponentBuilderClass implements GenericComponentBuilder {
             }
           : { x: 0, y: 0, z: 0 }
       rotation.z += ((pcb_component.rotation ?? 0) / Math.PI) * 180 // TODO HACK until pcb_component.rotation is in degrees
+
+      if (pcb_component.layer === "bottom") {
+        rotation.y = 180
+      }
+
       const cad_component: CadComponent = {
         type: "cad_component",
         cad_component_id: bc.getId("cad_component"),

--- a/tests/component-builder/cad-model-bottom-layer.test.ts
+++ b/tests/component-builder/cad-model-bottom-layer.test.ts
@@ -1,0 +1,34 @@
+import test from "ava"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { su } from "@tscircuit/soup-util"
+
+test("add cad_component on bottom layer", async (t) => {
+  const { pb, logSoup } = await getTestFixture(t)
+
+  const soup = await pb
+    .add("board", (bb) =>
+      bb
+        .setProps({
+          width: 18,
+          height: 26,
+        })
+        .add("bug", (bb) =>
+          bb.setProps({
+            name: "J1",
+            footprint: "pinrow5",
+            layer: "bottom",
+            cadModel: {
+              objUrl:
+                "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=6331f645d89e4b919bdba0cb4f3544ce&pn=C124379",
+            },
+          })
+        )
+    )
+    .build()
+
+  const cadComponent = su(soup).cad_component.list()[0]
+  t.is(cadComponent.layer, "bottom")
+  t.deepEqual(cadComponent.rotation, { x: 0, y: 180, z: 0 })
+
+  await logSoup(soup)
+})


### PR DESCRIPTION
closes https://github.com/tscircuit/tscircuit/issues/258

- **Add a test that checks that cad component has correct y coordinate when set to the bottom layer**
- **Set cad component y coordinate to 180 when it's layer set to bottom**

Debug [[link]](https://debug.tscircuit.com/soup_group/builder:%20add%20cad_component%20on%20bottom%20layer#%7B%22selected_engine%22%3A%223d%22%2C%22selected_layout_index%22%3A0%7D).

![image](https://github.com/user-attachments/assets/e2049ad2-821f-4637-855c-babacc491c84)