### PR TITLE
Add test to replicate duplicate port hints issue

### DIFF
--- a/src/lib/builder/component-builder/BugBuilder.ts
+++ b/src/lib/builder/component-builder/BugBuilder.ts
@@ -138,10 +138,11 @@ export class BugBuilderClass
     const port_indices = getPortIndices(port_arrangement)
     for (const pn of port_indices) {
       const portPosition = getPortPosition(extended_port_arrangement, pn)
+      const port_hints = [...new Set([port_labels[pn], pn.toString()])]
       this.ports.addPort({
         name: port_labels[pn],
         pin_number: pn,
-        port_hints: [port_labels[pn], pn],
+        port_hints,
         center: { x: portPosition.x, y: portPosition.y },
         facing_direction: convertSideToDirection(portPosition.side),
       })

--- a/tests/bug-builder/duplicate-port-hints.test.tsx
+++ b/tests/bug-builder/duplicate-port-hints.test.tsx
@@ -1,33 +1,31 @@
-import test from "ava";
-import { getTestFixture } from "../fixtures/get-test-fixture"; 
+import test from "ava"
+import { getTestFixture } from "../fixtures/get-test-fixture"
+import { su } from "@tscircuit/soup-util"
 
 test("replicate duplicate port hints issue", async (t) => {
-  try {
-    const { logSoup, pb } = await getTestFixture(t);
+  const { logSoup, pb } = await getTestFixture(t)
 
-    const soup = await pb
-      .add("bug", (cb) => {
-        cb.setProps({ footprint: "soic8" });
-      })
-      .build();
+  const soup = await pb
+    .add("bug", (cb) => {
+      cb.setProps({ footprint: "soic8" })
+    })
+    .build()
 
-    const su = require("@tscircuit/soup-util");
+  const sourcePorts = su(soup).source_port.list()
 
-    const sourcePorts = su(soup).source_port.list();
-
-    sourcePorts.forEach((port) => {
-      const portHintsSet = new Set(port.port_hints);
+  sourcePorts.forEach((port) => {
+    if (port.port_hints) {
+      const portHintsSet = new Set(port.port_hints)
 
       t.is(
         port.port_hints.length,
         portHintsSet.size,
         `Duplicate hints found in port ${port.name}`
-      );
-    });
+      )
+    } else {
+      t.fail(`port_hints is undefined for port ${port.name}`)
+    }
+  })
 
-    await logSoup(soup);
-  } catch (error) {
-    console.error("Error in test:", error);
-    t.fail(`Test failed due to error: ${error.message}`);
-  }
-});
+  await logSoup(soup)
+})

--- a/tests/bug-builder/duplicate-port-hints.test.tsx
+++ b/tests/bug-builder/duplicate-port-hints.test.tsx
@@ -13,10 +13,7 @@ test("replicate duplicate port hints issue", async (t) => {
 
   const sourcePorts = su(soup).source_port.list()
 
-  console.log("All source ports:", JSON.stringify(sourcePorts, null, 2))
-
   sourcePorts.forEach((port) => {
-    console.log(`Port ${port.name} hints:`, port.port_hints)
     if (port.port_hints) {
       const portHintsSet = new Set(port.port_hints)
 

--- a/tests/bug-builder/duplicate-port-hints.test.tsx
+++ b/tests/bug-builder/duplicate-port-hints.test.tsx
@@ -13,7 +13,10 @@ test("replicate duplicate port hints issue", async (t) => {
 
   const sourcePorts = su(soup).source_port.list()
 
+  console.log("All source ports:", JSON.stringify(sourcePorts, null, 2))
+
   sourcePorts.forEach((port) => {
+    console.log(`Port ${port.name} hints:`, port.port_hints)
     if (port.port_hints) {
       const portHintsSet = new Set(port.port_hints)
 

--- a/tests/bug-builder/duplicate-port-hints.test.tsx
+++ b/tests/bug-builder/duplicate-port-hints.test.tsx
@@ -1,0 +1,33 @@
+import test from "ava";
+import { getTestFixture } from "../fixtures/get-test-fixture"; 
+
+test("replicate duplicate port hints issue", async (t) => {
+  try {
+    const { logSoup, pb } = await getTestFixture(t);
+
+    const soup = await pb
+      .add("bug", (cb) => {
+        cb.setProps({ footprint: "soic8" });
+      })
+      .build();
+
+    const su = require("@tscircuit/soup-util");
+
+    const sourcePorts = su(soup).source_port.list();
+
+    sourcePorts.forEach((port) => {
+      const portHintsSet = new Set(port.port_hints);
+
+      t.is(
+        port.port_hints.length,
+        portHintsSet.size,
+        `Duplicate hints found in port ${port.name}`
+      );
+    });
+
+    await logSoup(soup);
+  } catch (error) {
+    console.error("Error in test:", error);
+    t.fail(`Test failed due to error: ${error.message}`);
+  }
+});


### PR DESCRIPTION
- [x] Added a test to replicate the issue of duplicate port hints by creating a `bug` with `footprint="soic8"`.
